### PR TITLE
Fix query_params for valueless params

### DIFF
--- a/lib/uri_parser.rb
+++ b/lib/uri_parser.rb
@@ -20,7 +20,7 @@ class URIParser
       {}.tap do |hash|
         k_v_pairs.each do |kv|
           key, value = kv.split('=')
-          hash[CGI.unescape(key)] = CGI.unescape(value)
+          hash[CGI.unescape(key)] = value && CGI.unescape(value)
         end
       end
     end

--- a/lib/uri_parser/version.rb
+++ b/lib/uri_parser/version.rb
@@ -1,3 +1,3 @@
 class URIParser
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/uri_parser_spec.rb
+++ b/spec/uri_parser_spec.rb
@@ -51,4 +51,9 @@ describe URIParser do
     its(:uri) { should == 'http://domain.com/?a%20param=a%20value' }
     its(:query_params) { should == { 'a param' => 'a value' } }
   end
+
+  describe_parsed 'http://domain.com?b=&c&d=5' do
+    its(:uri) { should == 'http://domain.com/?b=&c&d=5' }
+    its(:query_params) { should == { 'b' => nil, 'c' => nil, 'd' => '5' } }
+  end
 end


### PR DESCRIPTION
Before was raising error: 'NoMethodError: undefined method `tr' for nil:NilClass'

@davidann @greykn @myronmarston
