### PR TITLE
Fix compilation on MacOS.

### DIFF
--- a/ext/uri_parser/extconf.rb
+++ b/ext/uri_parser/extconf.rb
@@ -3,6 +3,7 @@ require 'mkmf'
 extension_name = 'uri_parser'
 
 $CFLAGS << ' -Wno-deprecated -g '
+$CXXFLAGS << ' -DUCHAR_TYPE=uint16_t '
 
 if RUBY_PLATFORM =~ /linux|darwin/
 	$libs << ' -lstdc++'


### PR DESCRIPTION
MacOS is missing the `char16_t` type because the standard header `uchar.h` is missing. This is documented here:

http://icu-project.org/apiref/icu4c/umachine_8h.html#a6bb9fad572d65b305324ef288165e2ac

This should be compatible on Linux as well.