### PR TITLE
Change canonicalize due to conflict.

### DIFF
--- a/ext/uri_parser/uri_parser.cc
+++ b/ext/uri_parser/uri_parser.cc
@@ -21,7 +21,7 @@ typedef VALUE (ruby_method_vararg)(...);
 // Prototype for the initialization method - Ruby calls this, not you
 void Init_uri_parser();
 
-bool canonicalize(const std::string& input_spec,
+bool canonicalize_url(const std::string& input_spec,
 			std::string* canonical,
 			url_parse::Parsed* parsed)
 {
@@ -57,7 +57,7 @@ VALUE uri_parser_initialize(VALUE self, VALUE in)
 	std::string canonical;
 	url_parse::Parsed parsed;
 	
-	bool valid = canonicalize(url, &canonical, &parsed);
+	bool valid = canonicalize_url(url, &canonical, &parsed);
 
 	rb_iv_set(self, "@"ATTR_PORT, component_rb_str(canonical, parsed.port));
 	rb_iv_set(self, "@"ATTR_HOST, component_rb_str(canonical, parsed.host));

--- a/lib/uri_parser/version.rb
+++ b/lib/uri_parser/version.rb
@@ -1,3 +1,3 @@
 class URIParser
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Changing the name due to the following error.
```
uri_parser.cc: In function ‘bool canonicalize(const string&, std::__cxx11::string*, url_parse::Parsed*)’:
uri_parser.cc:24:6: error: conflicting declaration of C function ‘bool canonicalize(const string&, std::__cxx11::string*, url_parse::Parsed*)’
 bool canonicalize(const std::string& input_spec,
      ^~~~~~~~~~~~
In file included from /usr/include/features.h:424:0,
                 from /usr/include/x86_64-linux-gnu/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from /home/lindsey/.rbenv/versions/2.3.7/include/ruby-2.3.0/ruby/defines.h:26,
                 from /home/lindsey/.rbenv/versions/2.3.7/include/ruby-2.3.0/ruby/ruby.h:36,
                 from /home/lindsey/.rbenv/versions/2.3.7/include/ruby-2.3.0/ruby.h:33,
                 from uri_parser.cc:1:
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:379:1: note: previous declaration ‘int canonicalize(double*, const double*)’
 __MATHDECL_1 (int, canonicalize,, (_Mdouble_ *__cx, const _Mdouble_ *__x));
 ^
```