### PR TITLE
Dp 9757/elise broken url parsing

### DIFF
--- a/lib/uri_parser.rb
+++ b/lib/uri_parser.rb
@@ -22,7 +22,9 @@ class URIParser
           key, value = kv.split('=')
           key = CGI.unescape(key) if !key.nil?
           v = CGI.unescape(value) if !value.nil?
-          hash[key] = value && v
+          if !key.nil? || !value.nil?
+            hash[key] = value && v
+          end
         end
       end
     end

--- a/lib/uri_parser.rb
+++ b/lib/uri_parser.rb
@@ -22,10 +22,9 @@ class URIParser
           key, value = kv.split('=')
           key = CGI.unescape(key) if !key.nil?
           v = CGI.unescape(value) if !value.nil?
-          if !key.nil? || !value.nil?
-            hash[key] = value && v
-          end
+          hash[key] = value && v
         end
+        hash.reject! {|key, value| key.nil? && value.nil?}
       end
     end
   end

--- a/lib/uri_parser.rb
+++ b/lib/uri_parser.rb
@@ -20,7 +20,9 @@ class URIParser
       {}.tap do |hash|
         k_v_pairs.each do |kv|
           key, value = kv.split('=')
-          hash[CGI.unescape(key)] = value && CGI.unescape(value)
+          key = CGI.unescape(key) if !key.nil?
+          v = CGI.unescape(value) if !value.nil?
+          hash[key] = value && v
         end
       end
     end

--- a/lib/uri_parser/version.rb
+++ b/lib/uri_parser/version.rb
@@ -1,3 +1,3 @@
 class URIParser
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/uri_parser_spec.rb
+++ b/spec/uri_parser_spec.rb
@@ -71,6 +71,4 @@ describe URIParser do
     its(:uri) { should == 'http://domain.com/?c=3&d=5&' }
     its(:query_params) { should == { 'c' => '3', 'd' => '5' } }
   end
-
-
 end

--- a/spec/uri_parser_spec.rb
+++ b/spec/uri_parser_spec.rb
@@ -56,4 +56,21 @@ describe URIParser do
     its(:uri) { should == 'http://domain.com/?b=&c&d=5' }
     its(:query_params) { should == { 'b' => nil, 'c' => nil, 'd' => '5' } }
   end
+
+  describe_parsed 'http://domain.com/?&c=3&d=5' do
+    its(:uri) { should == 'http://domain.com/?&c=3&d=5' }
+    its(:query_params) { should == { nil => nil, 'c' => '3', 'd' => '5' } }
+  end
+
+  describe_parsed 'http://domain.com/?c=3&&d=5' do
+    its(:uri) { should == 'http://domain.com/?c=3&&d=5' }
+    its(:query_params) { should == { 'c' => '3', nil => nil, 'd' => '5' } }
+  end
+
+  describe_parsed 'http://domain.com/?c=3&d=5&' do
+    its(:uri) { should == 'http://domain.com/?c=3&d=5&' }
+    its(:query_params) { should == { 'c' => '3', 'd' => '5' } }
+  end
+
+
 end

--- a/spec/uri_parser_spec.rb
+++ b/spec/uri_parser_spec.rb
@@ -57,18 +57,33 @@ describe URIParser do
     its(:query_params) { should == { 'b' => nil, 'c' => nil, 'd' => '5' } }
   end
 
+  # empty first param (query starts with &)
   describe_parsed 'http://domain.com/?&c=3&d=5' do
     its(:uri) { should == 'http://domain.com/?&c=3&d=5' }
-    its(:query_params) { should == { nil => nil, 'c' => '3', 'd' => '5' } }
+    its(:query_params) { should == { 'c' => '3', 'd' => '5' } }
   end
 
+  # empty param (query contains &&)
   describe_parsed 'http://domain.com/?c=3&&d=5' do
     its(:uri) { should == 'http://domain.com/?c=3&&d=5' }
-    its(:query_params) { should == { 'c' => '3', nil => nil, 'd' => '5' } }
+    its(:query_params) { should == { 'c' => '3', 'd' => '5' } }
   end
 
+  # empty final param (query ends with &)
   describe_parsed 'http://domain.com/?c=3&d=5&' do
     its(:uri) { should == 'http://domain.com/?c=3&d=5&' }
     its(:query_params) { should == { 'c' => '3', 'd' => '5' } }
+  end
+
+  # no values for any keys
+  describe_parsed 'http://domain.com/?&b&c&&d' do
+    its(:uri) { should == 'http://domain.com/?&b&c&&d' }
+    its(:query_params) { should == { 'b' => nil, 'c' => nil, 'd' => nil } }
+  end
+
+  # no key for value "c"
+  describe_parsed 'http://domain.com/?b&=c&d' do
+    its(:uri) { should == 'http://domain.com/?b&=c&d' }
+    its(:query_params) { should == { 'b' => nil, '' => 'c', 'd' => nil } }
   end
 end


### PR DESCRIPTION
Latest test suite output:
```
..................................

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /app/spec/uri_parser_spec.rb:15:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.00839 seconds (files took 0.06765 seconds to load)
34 examples, 0 failures
```